### PR TITLE
Incorrect character

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Just add the dependency to your project `build.gradle` file:
 
 ```groovy
 dependencies {  
-  compile 'com.cloudrail:cloudrail-si-android:2.16.6‘
+  compile 'com.cloudrail:cloudrail-si-android:2.16.6'
 }
 ```
 via [Maven Central](http://search.maven.org/#search|ga|1|a:"cloudrail-si-android")


### PR DESCRIPTION
There was a backtick character instead of apostrophe in Download section (in dependency example is)